### PR TITLE
returning offsets from the call to get the offsets from the group coo…

### DIFF
--- a/aiokafka/consumer/fetcher.py
+++ b/aiokafka/consumer/fetcher.py
@@ -876,6 +876,7 @@ class Fetcher:
                     timeout=None if remaining == float("inf") else remaining,
                     loop=self._loop
                 )
+                return offsets
             except asyncio.TimeoutError:
                 break
             except Errors.KafkaError as error:
@@ -888,8 +889,6 @@ class Fetcher:
                 if remaining < self._retry_backoff:
                     break
                 await asyncio.sleep(self._retry_backoff, loop=self._loop)
-            else:
-                return offsets
         raise KafkaTimeoutError(
             "Failed to get offsets by times in %s ms" % timeout_ms)
 


### PR DESCRIPTION
This is a fix for issue https://github.com/robinhood/aiokafka/issues/7 where the exception is swallowed instead of throwing it back to the application