### PR TITLE
forcing metadata update when client has stale cluster meta data

### DIFF
--- a/aiokafka/consumer/fetcher.py
+++ b/aiokafka/consumer/fetcher.py
@@ -988,6 +988,7 @@ class Fetcher:
                         "Attempt to fetch offsets for partition %s ""failed "
                         "due to obsolete leadership information, retrying.",
                         partition)
+                    self._client.force_metadata_update()
                     raise error_type(partition)
                 elif error_type is Errors.UnknownTopicOrPartitionError:
                     log.warning(


### PR DESCRIPTION
This issue resolves the issue described in https://github.com/robinhood/aiokafka/issues/9 by forcing a cluster metadata update