### PR TITLE
Call force_metadata_update once before raising the StaleMetadate exception in _get_conn method

### DIFF
--- a/aiokafka/client.py
+++ b/aiokafka/client.py
@@ -396,10 +396,10 @@ class AIOKafkaClient:
         try:
             if group == ConnectionGroup.DEFAULT:
                 broker = self.cluster.broker_metadata(node_id)
-                # XXX: earlier we only did an assert here, but it seems it's
-                # possible to get a leader that is for some reason not in
-                # metadata.
-                # I think requerying metadata should solve this problem
+                if broker is None:
+                    self.force_metadata_update()
+                    broker = self.cluster.broker_metadata(node_id)
+
                 if broker is None:
                     raise StaleMetadata(
                         'Broker id %s not in current metadata' % node_id)


### PR DESCRIPTION
With this PR, I hope to fix the following issue:

```
[2020-08-26 14:56:18,029] [1] [WARNING] Could not send <class 'aiokafka.protocol.transaction.AddOffsetsToTxnRequest_v0'>: StaleMetadata('Broker id 2 not in current metadata') 
[2020-08-26 14:56:18,130] [1] [WARNING] Could not send <class 'aiokafka.protocol.transaction.AddOffsetsToTxnRequest_v0'>: StaleMetadata('Broker id 2 not in current metadata') 
[2020-08-26 14:56:36,816] [1] [WARNING] Could not send <class 'aiokafka.protocol.transaction.TxnOffsetCommitRequest_v0'>: StaleMetadata('Broker id 0 not in current metadata') 
....
[2020-08-26 14:56:38,028] [1] [WARNING] Could not send <class 'aiokafka.protocol.transaction.TxnOffsetCommitRequest_v0'>: StaleMetadata('Broker id 0 not in current metadata') 
[2020-08-26 14:56:19,345] [1] [WARNING] Could not send <class 'aiokafka.protocol.transaction.AddOffsetsToTxnRequest_v0'>: StaleMetadata('Broker id 2 not in current metadata') 
[2020-08-26 14:56:38,129] [1] [WARNING] Could not send <class 'aiokafka.protocol.transaction.TxnOffsetCommitRequest_v0'>: StaleMetadata('Broker id 0 not in current metadata') 
[2020-08-26 14:56:19,446] [1] [WARNING] Could not send <class 'aiokafka.protocol.transaction.AddOffsetsToTxnRequest_v0'>: StaleMetadata('Broker id 2 not in current metadata')
```
This was flooding my application so much it could not handle any more requests, and was "falling" to enqueue message "silently".

Now, it will at least try to refresh the "staled" matadata once before raising the `StaleMetadata` Exception and retrying to send the message indefinitly.

