### PR TITLE
Don't send leave request when running in KIP-345

### DIFF
--- a/aiokafka/consumer/group_coordinator.py
+++ b/aiokafka/consumer/group_coordinator.py
@@ -419,9 +419,11 @@ class GroupCoordinator(BaseCoordinator):
         return task
 
     async def _maybe_leave_group(self):
-        if self.generation > 0:
+        if self.generation > 0 and self._group_instance_id is None:
             # this is a minimal effort attempt to leave the group. we do not
             # attempt any resending if the request fails or times out.
+            # Note: do not send this leave request if we are running in static
+            # partition assignment mode (when group_instance_id has been set).
             version = 0 if self._client.api_version < (0, 11, 0) else 1
             request = LeaveGroupRequest[version](self.group_id, self.member_id)
             try:


### PR DESCRIPTION
The earlier changes merged for KIP-345 (static membership protocol) missed an important part of the client changes: clients should not send a LeaveGroupRequest message when they quit or leave the group. The new protocol when in this mode is to wait for the client to either come back or the broker to time out the client if they really crashed. This allows clients to go away for a short-term event like a pod kill/restart without causing the rest of the pods to have to rebalance.